### PR TITLE
Fix alignment overrides

### DIFF
--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -694,7 +694,7 @@ mod constants {
         ("entRenderToTextureFeatures", 1),
         ("scneventsCameraOverrideSettings", 1),
         ("worldProxyCustomGeometryParams", 1),
-        ("netPeerID", 2),
+        ("netPeerID", 1),
         ("NavGenNavigationSetting", 2),
         ("vehicleVehicleSlotsState", 4),
     ];

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -696,6 +696,7 @@ mod constants {
         ("worldProxyCustomGeometryParams", 1),
         ("netPeerID", 1),
         ("NavGenNavigationSetting", 2),
+        ("TrafficGenDynamicTrafficSetting", 2),
         ("vehicleVehicleSlotsState", 4),
     ];
 }


### PR DESCRIPTION
Feel free to ignore this PR if irrelevant, as we already discussed it, but in case here are the fixes for `PeerID` and `TrafficGenDynamicTrafficSetting`.

This personally fix my tests in the [PR #3 for red4ext-rs-bindings](https://github.com/jac3km4/red4ext-rs-bindings/pull/3).